### PR TITLE
Applied patch for HDFS-4451 directly to our fork.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -1328,6 +1328,23 @@ public class Balancer {
     ReturnStatus(int code) {
       this.code = code;
     }
+    
+    int toExitCode() {
+      return toExitCode(this.code);
+    }
+
+    static int toExitCode(int code) {
+      switch (code) {
+        case 1:
+        case 0:
+
+          return 0;
+
+        default:
+
+          return 1;
+      }
+    }
   }
 
   /** Run an iteration for all datanodes. */
@@ -1494,7 +1511,12 @@ public class Balancer {
   }
 
   static class Cli extends Configured implements Tool {
-    /** Parse arguments and then run Balancer */
+    /**
+     * Parse arguments and then run Balancer.
+     * 
+     * @param args command specific arguments.
+     * @return exit code. 0 indicates success, non-zero indicates failure.
+     */
     @Override
     public int run(String[] args) {
       final long startTime = Time.now();
@@ -1507,13 +1529,14 @@ public class Balancer {
         checkReplicationPolicyCompatibility(conf);
 
         final Collection<URI> namenodes = DFSUtil.getNsServiceRpcUris(conf);
-        return Balancer.run(namenodes, parse(args), conf);
+        return ReturnStatus.toExitCode(
+                Balancer.run(namenodes, parse(args), conf));
       } catch (IOException e) {
         System.out.println(e + ".  Exiting ...");
-        return ReturnStatus.IO_EXCEPTION.code;
+        return ReturnStatus.IO_EXCEPTION.toExitCode();
       } catch (InterruptedException e) {
         System.out.println(e + ".  Exiting ...");
-        return ReturnStatus.INTERRUPTED.code;
+        return ReturnStatus.INTERRUPTED.toExitCode();
       } finally {
         System.out.println("Balancing took " + time2Str(Time.now()-startTime));
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
@@ -46,8 +46,10 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.server.balancer.Balancer.Cli;
 import org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset;
 import org.apache.hadoop.util.Time;
+import org.apache.hadoop.util.Tool;
 import org.junit.Test;
 
 /**
@@ -94,7 +96,6 @@ public class TestBalancer {
         replicationFactor, r.nextLong());
     DFSTestUtil.waitReplication(fs, filePath, replicationFactor);
   }
-
 
   /* fill up a cluster with <code>numNodes</code> datanodes 
    * whose used space to be <code>size</code>
@@ -301,10 +302,12 @@ public class TestBalancer {
    * @param racks - array of racks for original nodes in cluster
    * @param newCapacity - new node's capacity
    * @param newRack - new node's rack
+   * @param useTool - if true run test via Cli with command-line argument 
+   *   parsing, etc.   Otherwise invoke balancer API directly.
    * @throws Exception
    */
   private void doTest(Configuration conf, long[] capacities, String[] racks, 
-      long newCapacity, String newRack) throws Exception {
+      long newCapacity, String newRack, boolean useTool) throws Exception {
     assertEquals(capacities.length, racks.length);
     int numOfDatanodes = capacities.length;
     cluster = new MiniDFSCluster.Builder(conf)
@@ -330,7 +333,11 @@ public class TestBalancer {
       totalCapacity += newCapacity;
 
       // run balancer and validate results
-      runBalancer(conf, totalUsedSpace, totalCapacity);
+      if (useTool) {
+        runBalancerCli(conf, totalUsedSpace, totalCapacity);
+      } else {
+        runBalancer(conf, totalUsedSpace, totalCapacity);
+      }
     } finally {
       cluster.shutdown();
     }
@@ -350,22 +357,44 @@ public class TestBalancer {
     waitForBalancer(totalUsedSpace, totalCapacity, client, cluster);
   }
   
+  private void runBalancerCli(Configuration conf,
+      long totalUsedSpace, long totalCapacity) throws Exception {
+    waitForHeartBeat(totalUsedSpace, totalCapacity, client, cluster);
+
+    final Tool tool = new Cli();
+    
+    tool.setConf(conf);
+    
+    final String[] args = { "-policy", "datanode" };
+    
+    // start rebalancing
+
+    final int r = tool.run(args);
+    
+    assertEquals("Tools should exit 0 on success", 0, r);
+
+    waitForHeartBeat(totalUsedSpace, totalCapacity, client, cluster);
+    LOG.info("Rebalancing with default ctor.");
+    waitForBalancer(totalUsedSpace, totalCapacity, client, cluster);
+  }
+  
   /** one-node cluster test*/
-  private void oneNodeTest(Configuration conf) throws Exception {
+  private void oneNodeTest(Configuration conf, boolean useTool) throws Exception {
     // add an empty node with half of the CAPACITY & the same rack
-    doTest(conf, new long[]{CAPACITY}, new String[]{RACK0}, CAPACITY/2, RACK0);
+    doTest(conf, new long[]{CAPACITY}, new String[]{RACK0}, CAPACITY/2, 
+            RACK0, useTool);
   }
   
   /** two-node cluster test */
-  private void twoNodeTest(Configuration conf) throws Exception {
+  private void twoNodeTest(Configuration conf, boolean useTool) throws Exception {
     doTest(conf, new long[]{CAPACITY, CAPACITY}, new String[]{RACK0, RACK1},
-        CAPACITY, RACK2);
+        CAPACITY, RACK2, useTool);
   }
   
   /** test using a user-supplied conf */
   public void integrationTest(Configuration conf) throws Exception {
     initConf(conf);
-    oneNodeTest(conf);
+    oneNodeTest(conf, false);
   }
   
   /**
@@ -401,8 +430,8 @@ public class TestBalancer {
   
   void testBalancer0Internal(Configuration conf) throws Exception {
     initConf(conf);
-    oneNodeTest(conf);
-    twoNodeTest(conf);
+    oneNodeTest(conf, false);
+    twoNodeTest(conf, false);
   }
 
   /** Test unevenly distributed cluster */
@@ -462,6 +491,18 @@ public class TestBalancer {
     } finally {
       cluster.shutdown();
     }
+  }
+
+  /**
+   * Verify balancer exits 0 on success.
+   */
+  @Test(timeout=100000)
+  public void testExitZeroOnSuccess() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+
+    initConf(conf);
+
+    oneNodeTest(conf, true);
   }
 
   /**


### PR DESCRIPTION
Tested like so:

$ mvn clean install -fn -Pnative -Dmaven.javadoc.skip=true -DskipTests -DHadoopPatchProcess
$ cd hadoop-hdfs-project/hadoop-hdfs
$ mvn test -fn -Drequire.test.libhadoop -DHadoopPatchProcess -Dtest=TestBalancer
## ...
##  T E S T S

Running org.apache.hadoop.hdfs.server.balancer.TestBalancer
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 61.528 sec

Results :

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:17.148s
[INFO] Finished at: Tue Jan 29 14:08:06 PST 2013
[INFO] Final Memory: 26M/361M
[INFO] ------------------------------------------------------------------------
