### PR TITLE
DP-205 Forward merging HADOOP-3733 and HDFS-4505

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3/S3Credentials.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3/S3Credentials.java
@@ -50,7 +50,7 @@ public class S3Credentials {
       int index = userInfo.indexOf(':');
       if (index != -1) {
         accessKey = userInfo.substring(0, index);
-        secretAccessKey = userInfo.substring(index + 1);
+        secretAccessKey = userInfo.substring(index + 1).replace("%2F","/");
       } else {
         accessKey = userInfo;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3/S3FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3/S3FileSystem.java
@@ -91,7 +91,7 @@ public class S3FileSystem extends FileSystem {
     }
     store.initialize(uri, conf);
     setConf(conf);
-    this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority());    
+    this.uri = URI.create(uri.getScheme() + "://" + uri.getRawAuthority());
     this.workingDir =
       new Path("/user", System.getProperty("user.name")).makeQualified(this);
   }  

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3native/NativeS3FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/s3native/NativeS3FileSystem.java
@@ -271,7 +271,7 @@ public class NativeS3FileSystem extends FileSystem {
     }
     store.initialize(uri, conf);
     setConf(conf);
-    this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority());
+    this.uri = URI.create(uri.getScheme() + "://" + uri.getRawAuthority());
     this.workingDir =
       new Path("/user", System.getProperty("user.name")).makeQualified(this);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/PathData.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/PathData.java
@@ -247,7 +247,7 @@ public class PathData implements Comparable<PathData> {
     // check getPath() so scheme slashes aren't considered part of the path
     String separator = uri.getPath().endsWith(Path.SEPARATOR)
         ? "" : Path.SEPARATOR;
-    return uri + separator + basename;
+    return new Path(uri).toString() + separator + basename;
   }
   
   protected enum PathType { HAS_SCHEME, SCHEMELESS_ABSOLUTE, RELATIVE };
@@ -300,7 +300,7 @@ public class PathData implements Comparable<PathData> {
             if (globUri.getAuthority() == null) {
               matchUri = removeAuthority(matchUri);
             }
-            globMatch = matchUri.toString();
+            globMatch = new Path(matchUri).toString();
             break;
           case SCHEMELESS_ABSOLUTE: // take just the uri's path
             globMatch = matchUri.getPath();
@@ -411,7 +411,7 @@ public class PathData implements Comparable<PathData> {
 
   /** Construct a URI from a String with unescaped special characters
    *  that have non-standard sematics. e.g. /, ?, #. A custom parsing
-   *  is needed to prevent misbihaviors.
+   *  is needed to prevent misbehaviors.
    *  @param pathString The input path in string form
    *  @return URI
    */

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/s3/TestS3Credentials.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/s3/TestS3Credentials.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.fs.s3;
 import java.net.URI;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
 
 public class TestS3Credentials extends TestCase {
+
+  @Test(timeout=10000)
   public void testInvalidHostnameWithUnderscores() throws Exception {
     S3Credentials s3Credentials = new S3Credentials();
     try {
@@ -33,4 +36,18 @@ public class TestS3Credentials extends TestCase {
       assertEquals("Invalid hostname in URI s3://a:b@c_d", e.getMessage());
     }
   }
+
+  @Test(timeout=10000)
+  public void testUserInfo() throws Exception {
+    S3Credentials s3Credentials = new S3Credentials();
+    // The URI needs to be carefully constructed to cause the initialize code
+    // to fail with an undecoded %2F in the same way that it fails when trying
+    // to use the code with hadoop fs, distcp, or other user-level tools.
+    s3Credentials.initialize(new URI("s3", "my_access_key:+MyVerysecret%2FK3y@s3.hostname.com", 
+				     null, null, null),
+			     new Configuration());
+    assertEquals(s3Credentials.getAccessKey(), "my_access_key");
+    assertEquals(s3Credentials.getSecretAccessKey(), "+MyVerysecret/K3y");
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/s3/TestS3FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/s3/TestS3FileSystem.java
@@ -37,6 +37,9 @@ public class TestS3FileSystem extends TestCase {
     initializationTest("s3://c", "s3://c");
     initializationTest("s3://c/", "s3://c");
     initializationTest("s3://c/path", "s3://c");
+    initializationTest("s3://a:b%2Fwith%2Fescaped%2Fslashes@c", "s3://a:b%2Fwith%2Fescaped%2Fslashes@c");
+    initializationTest("s3://a:b%2Fwith%2Fescaped%2Fslashes@c/", "s3://a:b%2Fwith%2Fescaped%2Fslashes@c");
+    initializationTest("s3://a:b%2Fwith%2Fescaped%2Fslashes@c/path", "s3://a:b%2Fwith%2Fescaped%2Fslashes@c");
   }
   
   private void initializationTest(String initializationUri, String expectedUri)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -34,6 +34,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMESERVICE_ID;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -368,6 +369,54 @@ public class DFSUtil {
   }
 
   /**
+   * Method to convert host addresses of a set of URIs to IP addresses and
+   * returns the unique ones.
+   *
+   * @param uris a collection of all configured URIs
+   * @return a collection of unique URIs with their host addresses in IP form.
+   */
+  public static Collection<URI> ipizeAndRemoveDuplicates(Collection<URI> uris) {
+    Set<URI> ret = new HashSet<URI>();
+
+    // For each URI, we convert the host to IP address, standardize them and
+    // finally compare them to pick out the unique ones.
+    for (URI uri : uris) {
+      // Get the scheme, host address and port number of each URI.
+      String scheme = uri.getScheme();
+      Integer port = uri.getPort();
+
+      // Resolve hostname into IP address.
+      String address = "";
+      try {
+        address = InetAddress.getByName(uri.getHost()).getHostAddress();
+      } catch (Exception e) {
+        // If we fail to resolve the hostname into IP, we fall back to
+        // use the hostname.
+        address = uri.getHost();
+      }
+
+      // Concatenate the parsed URI into a new one before re-inserting
+      // it into the final set.
+      StringBuilder fullAddrStr = new StringBuilder();
+      if (scheme != null && !scheme.equals(""))
+        fullAddrStr.append(scheme + "://");
+      fullAddrStr.append(address);
+      if (port != -1) fullAddrStr.append(":" + port);
+
+      // Add the parsed full address into the final set.
+      try {
+        ret.add(new URI(fullAddrStr.toString()));
+      } catch (URISyntaxException ue) {
+        // Should not reach here as the input should be well-configured
+        // URIs.
+        throw new IllegalArgumentException(ue);
+       }
+    }
+
+    return ret;
+  }
+
+  /**
    * @return <code>coll</code> if it is non-null and non-empty. Otherwise,
    * returns a list with a single null value.
    */
@@ -699,6 +748,20 @@ public class DFSUtil {
   }
 
   /**
+   * Same as {@link DFSUtil#getNsServiceRpcUris getNsServiceRpcUris} other than
+   * this method only return nameservices which are different in IP or port.
+   *
+   * @param conf configuration
+   * @return a collection of unique and configured NN URIs, preferring service
+   *         addresses
+   */
+  public static Collection<URI> getUniqueNsServiceRpcUris(Configuration conf) {
+    return getUniqueNameServiceUris(conf,
+        DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY,
+        DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY);
+  }
+
+  /**
    * Get a URI for each configured nameservice. If a nameservice is
    * HA-enabled, then the logical URI of the nameservice is returned. If the
    * nameservice is not HA-enabled, then a URI corresponding to the address of
@@ -776,8 +839,22 @@ public class DFSUtil {
         !nonPreferredUris.contains(defaultUri)) {
       ret.add(defaultUri);
     }
-    
     return ret;
+  }
+
+  /**
+   * Same as {@link DFSUtil#getNameServiceUris getNameServiceUris} other than
+   * this method only return nameservices which are different in IP or port.
+   *
+   * @param conf configuration
+   * @param keys configuration keys to try in order to get the URI for non-HA
+   *        nameservices
+   * @return a collection of all configured NN URIs are unique based on IP and
+   *         port combination.
+   */
+  public static Collection<URI> getUniqueNameServiceUris(Configuration conf,
+      String... keys) {
+    return ipizeAndRemoveDuplicates(getNameServiceUris(conf, keys));
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -1513,7 +1513,7 @@ public class Balancer {
       try {
         checkReplicationPolicyCompatibility(conf);
 
-        final Collection<URI> namenodes = DFSUtil.getNsServiceRpcUris(conf);
+        final Collection<URI> namenodes = DFSUtil.getUniqueNsServiceRpcUris(conf);
         return Balancer.run(namenodes, parse(args), conf);
       } catch (IOException e) {
         System.out.println(e + ".  Exiting ...");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/NameNodeConnector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/NameNodeConnector.java
@@ -165,7 +165,9 @@ class NameNodeConnector {
    */
   private OutputStream checkAndMarkRunningBalancer() throws IOException {
     try {
-      final DataOutputStream out = fs.create(BALANCER_ID_PATH);
+      // A balancer will not be able to create the file while another one is
+      // running.
+      final DataOutputStream out = fs.create(BALANCER_ID_PATH, false);
       out.writeBytes(InetAddress.getLocalHost().getHostName());
       out.flush();
       return out;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -36,14 +36,17 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
@@ -190,6 +193,34 @@ public class TestDFSUtil {
     assertEquals(2, nameserviceIds.size());
     assertEquals("nn1", it.next().toString());
     assertEquals("nn2", it.next().toString());
+  }
+
+  /**
+   * Test {@link DFSUtil#ipizeAndRemoveDuplicates(Collection<URI>)}
+   */
+  @Test
+  public void testIpizeAndRemoveDuplicates() throws URISyntaxException {
+    Set<URI> input = new HashSet<URI>();
+    Collection<URI> output = new HashSet<URI>();
+
+    input.add(new URI("hdfs://localhost:8000"));
+    input.add(new URI("hdfs://localhost:8000/"));
+    input.add(new URI("hdfs://127.0.0.1:8001/"));
+    input.add(new URI("hdfs://127.0.0.1:8020"));
+    output = DFSUtil.ipizeAndRemoveDuplicates(input);
+
+    // Get the localhost to IP mapping.
+    String localhost = "";
+    try {
+      localhost = InetAddress.getByName("localhost").getHostAddress();
+    } catch (Exception e) {
+      localhost = "localhost";
+    }
+
+    assertEquals(true, output.contains(new URI("hdfs://" + localhost + ":8000")));
+    assertEquals(true, output.contains(new URI("hdfs://127.0.0.1:8001")));
+    assertEquals(true, output.contains(new URI("hdfs://127.0.0.1:8020")));
+    assertEquals(3, output.size());
   }
   
   @Test


### PR DESCRIPTION
Merged patches for HADOOP-3733 and HDFS-4505

Squashed commit of the following:

commit df873eb3e5179d2c80682548285996dd59e735c3
Author: Abin Shahab ashahab@altiscale.com
Date:   Wed Nov 13 16:13:58 2013 -0800

```
HADOOP-3733 AE-173 patch forward merged to 2.0.5

"s3:" URLs break when Secret Key contains a slash, even if encoded
Done as part of DP-205
```

commit 1d5dcae8eac4264e72ccdaa14668a9d4223ea4a5
Author: Abin Shahab ashahab@altiscale.com
Date:   Wed Nov 13 16:07:53 2013 -0800

```
HDFS-4505 OPS-744 patch forward merged to 2.0.5
```
