### PR TITLE
DP-426 Parametrized rtmax,wtmax,and dtperf(HDFS-6080)

### DIFF
--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/nfs/nfs3/Nfs3Constant.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/nfs/nfs3/Nfs3Constant.java
@@ -205,7 +205,12 @@ public class Nfs3Constant {
   public static final String FILE_DUMP_DIR_DEFAULT = "/tmp/.hdfs-nfs";
   public static final String ENABLE_FILE_DUMP_KEY = "dfs.nfs3.enableDump";
   public static final boolean ENABLE_FILE_DUMP_DEFAULT = true;
-  
+  public static final String MAX_READ_TRANSFER_SIZE_KEY = "dfs.nfs3.rtmax";
+  public static final int MAX_READ_TRANSFER_SIZE_DEFAULT = 64 * 1024;
+  public static final String MAX_WRITE_TRANSFER_SIZE_KEY = "dfs.nfs3.wtmax";
+  public static final int MAX_WRITE_TRANSFER_SIZE_DEFAULT = 64 * 1024;
+  public static final String MAX_READDIR_TRANSFER_SIZE_KEY = "dfs.nfs3.dtmax";
+  public static final int MAX_READDIR_TRANSFER_SIZE_DEFAULT = 64 * 1024;
   public final static String UNKNOWN_USER = "nobody";
   public final static String UNKNOWN_GROUP = "nobody";
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/RpcProgramNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/RpcProgramNfs3.java
@@ -139,9 +139,6 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
       (short) DEFAULT_UMASK);
   
   static final Log LOG = LogFactory.getLog(RpcProgramNfs3.class);
-  private static final int MAX_READ_TRANSFER_SIZE = 64 * 1024;
-  private static final int MAX_WRITE_TRANSFER_SIZE = 64 * 1024;
-  private static final int MAX_READDIR_TRANSFER_SIZE = 64 * 1024;
 
   private final Configuration config = new Configuration();
   private final WriteManager writeManager;
@@ -547,7 +544,9 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
             + handle.getFileId());
         return new READLINK3Response(Nfs3Status.NFS3ERR_SERVERFAULT);
       }
-      if (MAX_READ_TRANSFER_SIZE < target.getBytes().length) {
+      int rtmax = config.getInt(Nfs3Constant.MAX_READ_TRANSFER_SIZE_KEY,
+              Nfs3Constant.MAX_READ_TRANSFER_SIZE_DEFAULT);
+      if (rtmax < target.getBytes().length) {
         return new READLINK3Response(Nfs3Status.NFS3ERR_IO, postOpAttr, null);
       }
 
@@ -631,7 +630,9 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
     }
     
     try {
-      int buffSize = Math.min(MAX_READ_TRANSFER_SIZE, count);
+      int rtmax = config.getInt(Nfs3Constant.MAX_READ_TRANSFER_SIZE_KEY,
+              Nfs3Constant.MAX_READ_TRANSFER_SIZE_DEFAULT);
+      int buffSize = Math.min(rtmax, count);
       byte[] readbuffer = new byte[buffSize];
 
       DFSInputStream is = dfsClient.open(Nfs3Utils.getFileIdPath(handle));
@@ -1644,10 +1645,12 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
     }
 
     try {
-      int rtmax = MAX_READ_TRANSFER_SIZE;
-      int wtmax = MAX_WRITE_TRANSFER_SIZE;
-      int dtperf = MAX_READDIR_TRANSFER_SIZE;
-
+      int rtmax = config.getInt(Nfs3Constant.MAX_READ_TRANSFER_SIZE_KEY,
+              Nfs3Constant.MAX_READ_TRANSFER_SIZE_DEFAULT);
+      int wtmax = config.getInt(Nfs3Constant.MAX_WRITE_TRANSFER_SIZE_KEY,
+              Nfs3Constant.MAX_WRITE_TRANSFER_SIZE_DEFAULT);
+      int dtperf = config.getInt(Nfs3Constant.MAX_READDIR_TRANSFER_SIZE_KEY,
+              Nfs3Constant.MAX_READDIR_TRANSFER_SIZE_DEFAULT);
       Nfs3FileAttributes attrs = Nfs3Utils.getFileAttr(dfsClient,
           Nfs3Utils.getFileIdPath(handle), iug);
       if (attrs == null) {


### PR DESCRIPTION
Parametrized rtmax,wtmax,and dtperf for HDFS-6080. In hdfs-site.xml,
this can be enhanced with dfs.nfs3.rtmax, dfs.nfs3.wtmax, and
dfs.nfs3.dtmax respectively.
